### PR TITLE
Add example on how to use gitlab-ci as a task scheduler and backup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,8 @@ backup:
     - docker run -it --rm -e CF_API_KEY="$CF_API_KEY" -e CF_API_EMAIL="$CF_API_EMAIL" lfaoro/flares $CF_DOMAINS_TO_BACKUP > backup/backup.bind
   artifacts:
     untracked: true
-    expire_in: 4 week
+    # uncomment (default is forever on gitlab.com)
+    # expire_in: 4 week
     name: "backup-${CI_COMMIT_REF_NAME}"
     paths:
      - backup/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,15 +6,16 @@ services:
   - docker:dind
 
 backup:
+  image: docker
+  stage: build
   retry: 2
   script:
-    - mkdir backup
     # CloudFlare auth key is here: https://dash.cloudflare.com/profile -> Global API Key -> View
-    - docker run -it --rm -e CF_API_KEY="$CF_API_KEY" -e CF_API_EMAIL="$CF_API_EMAIL" lfaoro/flares $CF_DOMAINS_TO_BACKUP > backup/backup.bind
+    - docker run -t --rm -e CF_API_KEY="$CF_API_KEY" -e CF_API_EMAIL="$CF_API_EMAIL" lfaoro/flares $CF_DOMAINS_TO_BACKUP > dns-backup-bind.txt
   artifacts:
     untracked: true
-    # uncomment (default is forever on gitlab.com)
+    # uncomment if needed (default is forever on gitlab.com)
     # expire_in: 4 week
-    name: "backup-${CI_COMMIT_REF_NAME}"
+    name: "backup-${date}"
     paths:
-     - backup/
+     - dns-backup-bind.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+variables:
+  GIT_STRATEGY: fetch
+  DOCKER_DRIVER: overlay
+
+services:
+  - docker:dind
+
+backup:
+  retry: 2
+  script:
+    - mkdir backup
+    # CloudFlare auth key is here: https://dash.cloudflare.com/profile -> Global API Key -> View
+    - docker run -it --rm -e CF_API_KEY="$CF_API_KEY" -e CF_API_EMAIL="$CF_API_EMAIL" lfaoro/flares $CF_DOMAINS_TO_BACKUP > backup/backup.bind
+  artifacts:
+    untracked: true
+    expire_in: 4 week
+    name: "backup-${CI_COMMIT_REF_NAME}"
+    paths:
+     - backup/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ $ flaredns domain.tld
 $ flaredns domain.tld --export /tmp/tables
 ```
 
+### Run backup with Gitlab-CI
+
+- Copy [.gitlab-ci.yml](.gitlab-ci.yml) inside an empty gitlab project
+- Use the [pipeline schedule feature](https://gitlab.com/help/user/project/pipelines/schedules)
+- Each task run will store backup as artifacts
+
 # Contributing
 
 > Any help and suggestions are very welcome and appreciated. Start by opening an [issue](https://github.com/lfaoro/flares/issues/new).


### PR DESCRIPTION
Note : an improvement to this PR could be to build each time `flares` from scratch for obvious security reasons.