### PR TITLE
fix: increase http timeout over the cloudflare client

### DIFF
--- a/internal/cloudflare/cloudflare.go
+++ b/internal/cloudflare/cloudflare.go
@@ -30,6 +30,7 @@ type Cloudflare struct {
 	Client    http.Client
 }
 
+// New returns a Cloudflare client
 func New(apiKey, apiEmail string) Cloudflare {
 	if apiKey == "" || apiEmail == "" {
 		panic(errNoAuthorization)
@@ -39,7 +40,7 @@ func New(apiKey, apiEmail string) Cloudflare {
 		AuthKey:   apiKey,
 		AuthEmail: apiEmail,
 		Client: http.Client{
-			Timeout: time.Second * 5,
+			Timeout: time.Second * 30,
 		},
 	}
 	return client

--- a/internal/cloudflare/cloudflare_test.go
+++ b/internal/cloudflare/cloudflare_test.go
@@ -44,13 +44,13 @@ func TestNew(t *testing.T) {
 		},
 	}
 	t.Run("NewClientApiEmpty", func(t *testing.T) {
-		assert.PanicsWithValue(t, "cloudflare: missing required AuthKey, AuthEmail", func() { New("", "email") })
+		assert.PanicsWithValue(t, errNoAuthorization, func() { New("", "email") })
 	})
 	t.Run("NewClientEmailEmpty", func(t *testing.T) {
-		assert.PanicsWithValue(t, "cloudflare: missing required AuthKey, AuthEmail", func() { New("api", "") })
+		assert.PanicsWithValue(t, errNoAuthorization, func() { New("api", "") })
 	})
 	t.Run("NewClientWithApiAndEmailEmpty", func(t *testing.T) {
-		assert.PanicsWithValue(t, "cloudflare: missing required AuthKey, AuthEmail", func() { New("", "") })
+		assert.PanicsWithValue(t, errNoAuthorization, func() { New("", "") })
 	})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/cloudflare/cloudflare_test.go
+++ b/internal/cloudflare/cloudflare_test.go
@@ -8,11 +8,58 @@ package cloudflare
 
 import (
 	"fmt"
+	"net/http"
 	"os"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNew(t *testing.T) {
+	type args struct {
+		apiKey   string
+		apiEmail string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Cloudflare
+	}{
+		{
+			"NewCloudFlareClient",
+			args{
+				"key",
+				"email",
+			},
+			Cloudflare{
+				API:       "https://api.cloudflare.com/client/v4",
+				AuthKey:   "key",
+				AuthEmail: "email",
+				Client: http.Client{
+					Timeout: time.Second * 30,
+				},
+			},
+		},
+	}
+	t.Run("NewClientApiEmpty", func(t *testing.T) {
+		assert.PanicsWithValue(t, "cloudflare: missing required AuthKey, AuthEmail", func() { New("", "email") })
+	})
+	t.Run("NewClientEmailEmpty", func(t *testing.T) {
+		assert.PanicsWithValue(t, "cloudflare: missing required AuthKey, AuthEmail", func() { New("api", "") })
+	})
+	t.Run("NewClientWithApiAndEmailEmpty", func(t *testing.T) {
+		assert.PanicsWithValue(t, "cloudflare: missing required AuthKey, AuthEmail", func() { New("", "") })
+	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.args.apiKey, tt.args.apiEmail); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestCloudflare_Zones(t *testing.T) {
 


### PR DESCRIPTION
I constantly get this error raised during the backups of our zones:

```go
ERROR: Get https://api.cloudflare.com/client/v4/zones?name=zone: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

When I increased the HTTP timeout over the client to `30`, I no longer experienced this error.